### PR TITLE
fix: Missing type on struct with package name

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -13,12 +13,15 @@ type Tag struct {
 	DataType string
 }
 
+// GetType determine type from expression
 func GetType(n ast.Expr) string {
 	switch x := n.(type) {
 	case *ast.ArrayType:
 		return "[]" + GetType(x.Elt)
 	case *ast.Ident:
 		return x.Name
+	case *ast.SelectorExpr:
+		return fmt.Sprintf("%s.%s", GetType(x.X), GetType(x.Sel))
 	case *ast.StarExpr:
 		return "*" + GetType(x.X)
 	case *ast.MapType:
@@ -28,7 +31,7 @@ func GetType(n ast.Expr) string {
 	}
 }
 
-// GetTags get tag from existing tags
+// GetTags from existing tags
 func GetTags(f *ast.File, structName, tag string) []Tag {
 	if tag == "" {
 		tag = `opt`

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -36,6 +36,9 @@ func TestGetOptTags(t *testing.T) {
 
 		field3 = generator.Tag{Name: "Field3",
 			DataType: "map[byte]float64"}
+
+		field4 = generator.Tag{Name: "Field4",
+			DataType: "http.Header"}
 	)
 	type args struct {
 		sourcePath string
@@ -72,7 +75,7 @@ func TestGetOptTags(t *testing.T) {
 		},
 		"All": {
 			args: args{sourcePath: ".././testfile/foo.sample", Tag: "_all_", structName: "Thing"},
-			want: []generator.Tag{field1, field2, field3},
+			want: []generator.Tag{field1, field2, field3, field4},
 		},
 	}
 	for name, tt := range tests {
@@ -98,6 +101,10 @@ func Test_getType(t *testing.T) {
 		"ident": {
 			args: args{&ast.Ident{Name: "int"}},
 			want: "int",
+		},
+		"header": {
+			args: args{&ast.Ident{Name: "http.Header"}},
+			want: "http.Header",
 		},
 		"empty": {
 			args: args{nil},

--- a/testfile/foo.sample
+++ b/testfile/foo.sample
@@ -1,9 +1,14 @@
 package foo
 
+import (
+    "net/http"
+)
+
 type Thing struct {
     Field1 string `opt` 
     Field2 []*int  `opt`
     Field3 map[byte]float64
+    Field4 http.Header
 }
 
 type ThingThong struct {


### PR DESCRIPTION
Current version will return empty type for example using `http.Header` as struct type